### PR TITLE
Fix Issue #1 - Compatibility with older Bash versions and different awk implementations

### DIFF
--- a/df.tmux
+++ b/df.tmux
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
-declare -A df_interpolation_cmd
-
-df_interpolations=( "\#{df_avail}" "\#{df_percent}" )
-df_interpolation_cmd["\#{df_avail}"]=$(df -h | awk '{if ($6 == "/") {print $4}}')
-df_interpolation_cmd["\#{df_percent}"]=$(df -h | awk '{if ($6 == "/") {print $5}}')
+df_interpolations=(
+    "\#{df_avail}"
+    "\#{df_percent}"
+)
+df_interpolation_cmd=(
+    "$(df -h | awk '{if ($6 == "/") {print $4}}')"
+    "$(df -h | awk '{if ($6 == "/") {print $5}}')"
+)
 
 get_tmux_option() {
     local option=$1
@@ -25,10 +28,10 @@ set_tmux_option() {
 }
 
 do_interpolation() {
-    local result=$1
-    for string in "${df_interpolations[@]}"; do
+    local result="$1"
+    for ((i=0; i < ${#df_interpolations[@]}; i++)); do
         local cmd="${df_interpolation_cmd[$string]}"
-	    result="${result/$string/$cmd}"
+	    result="${result//${df_interpolations[$i]}/${df_interpolation_cmd[$i]}}"
     done
     echo "$result" 
 }

--- a/df.tmux
+++ b/df.tmux
@@ -5,8 +5,8 @@ df_interpolations=(
     "\#{df_percent}"
 )
 df_interpolation_cmd=(
-    "$(df -h | awk '{if ($6 == "/") {print $4}}')"
-    "$(df -h | awk '{if ($6 == "/") {print $5}}')"
+    "$(df -h / | awk '{print $4}' | tail -n 1)"
+    "$(df -h / | awk '{print $5}' | tail -n 1)"
 )
 
 get_tmux_option() {


### PR DESCRIPTION
This is a fix for issue #1. Thanks to [suckerSlayer](https://github.com/suckerSlayer) for reporting the issue and helping to deduce a solution.

# Changes in this pull request
- Changed an associative array (hashmap) into a normal array. This makes the plugin work with older versions of Bash (specifically tested on Bash 3.2.57)
- Filter output of `df` by doing `df -h /` instead of just `df -h`. This means `awk` doesn't have to filter the result, which makes the plugin less reliant on awk (which seems to have many incompatible implementations)